### PR TITLE
Added missing NSString delineators around 'value'

### DIFF
--- a/Postmodern Programming.md
+++ b/Postmodern Programming.md
@@ -435,7 +435,7 @@ There are strong similarities with `Memo`, and maybe we should think about abstr
 		self.navigationItem.title = state[@"title"];
 		self.navigationItem.prompt = state[@"prompt"];
     }];
-    [sink addDependencyWithObject:memo keyPath:value];
+    [sink addDependencyWithObject:memo keyPath:@"value"];
 }
 ```
 


### PR DESCRIPTION
In the last line of the last viewDidLoad implementation, 'value' needs to be quoted.
